### PR TITLE
Address compiler warnings

### DIFF
--- a/stmload.c
+++ b/stmload.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "st2play.h"
 #include "stmload.h"

--- a/stmod.c
+++ b/stmod.c
@@ -62,7 +62,6 @@ static int sdl_init(st2_context_t *ctx)
 
 int main(int argc, char *argv[])
 {
-	int i;
 	st2_context_t *context;
 
 	if (argc < 2)


### PR DESCRIPTION
Address compiler warnings issued by gcc 7.2.1.